### PR TITLE
Remove prints from login_for_access_token

### DIFF
--- a/main.py
+++ b/main.py
@@ -855,9 +855,9 @@ def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
         data={"sub": user.username, "roles": role_names},
         expires_delta=access_token_expires,
     )
-    print("============================================")
-    print({"access_token": access_token, "token_type": "bearer","roles": role_names  })
-    print("============================================")
+    logger.debug(
+        "Issued access token for user %s with roles %s", user.username, role_names
+    )
     return {"access_token": access_token, "token_type": "bearer","roles": role_names  }
 
 


### PR DESCRIPTION
## Summary
- eliminate print statements in `login_for_access_token`
- add a debug log instead

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853c63616808326ba71639db670bb0b