### PR TITLE
Fix environment variable retrieval

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DB_URL = "mysql+mysqlconnector://street:!#Street@127.0.0.1:3306/parking_management"
+DATABASE_URL = "mysql+mysqlconnector://street:!#Street@127.0.0.1:3306/parking_management"

--- a/config.py
+++ b/config.py
@@ -8,14 +8,14 @@ import os
 
 # The application requires a database connection string in `DATABASE_URL`.
 # No default credentials are provided.
-DATABASE_URL = os.environ.get["DATABASE_URL"]
+DATABASE_URL = os.environ.get("DATABASE_URL")
 
 # ─────────────────────────────────────────────────────────────────────────────
 # API Tokens
 # ─────────────────────────────────────────────────────────────────────────────
 # Token for the OCR service must be provided via the `OCR_TOKEN` environment
 # variable.
-OCR_TOKEN = os.environ.get["OCR_TOKEN"]
+OCR_TOKEN = os.environ.get("OCR_TOKEN")
 # Location specific configuration now stores the Parkonic API token and camera
 # credentials.  The global constants previously defined here have been
 # deprecated.

--- a/db.py
+++ b/db.py
@@ -10,7 +10,7 @@ load_dotenv()
 # ─── Database connection ───
 # `DATABASE_URL` must be supplied by the environment.  No credentials are
 # stored in the repository.
-DATABASE_URL = os.getenv["DB_URL"]
+DATABASE_URL = os.environ.get("DATABASE_URL")
 
 # Create engine with pool_pre_ping so that any stale connection is auto‐replaced,
 # pool_recycle so we don’t hold sockets open past typical wait_timeout,


### PR DESCRIPTION
## Summary
- correct `os.environ.get` calls
- use `DATABASE_URL` across config and db
- update `.env` to match variable name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853db3cc7ac832686e7d53d5885c960