### PR TITLE
Add rtsp_path support for camera frame retrieval

### DIFF
--- a/camera_clip.py
+++ b/camera_clip.py
@@ -108,16 +108,21 @@ def fetch_camera_frame(
     camera_ip: str,
     username: str,
     password: str,
+    rtsp_path: str = "/",
     max_attempts: int = 20,
 ) -> bytes:
     """Return a JPEG snapshot from the camera using RTSP.
 
-    The stream is opened once and up to ``max_attempts`` frames are read,
-    sleeping briefly between tries, until a valid frame is obtained. If no
-    frame is read the function raises ``RuntimeError``.
+    ``rtsp_path`` allows specifying the full stream path (e.g.
+    ``/Streaming/Channels/101``). The stream is opened once and up to
+    ``max_attempts`` frames are read, sleeping briefly between tries, until
+    a valid frame is obtained. If no frame is read the function raises
+    ``RuntimeError``.
     """
 
-    rtsp_url = f"rtsp://{username}:{password}@{camera_ip}:554/"
+    if not rtsp_path.startswith("/"):
+        rtsp_path = "/" + rtsp_path
+    rtsp_url = f"rtsp://{username}:{password}@{camera_ip}:554{rtsp_path}"
     stream = VideoStream(rtsp_url).start()
     try:
         for _ in range(max_attempts):

--- a/ocr_processor.py
+++ b/ocr_processor.py
@@ -88,7 +88,8 @@ def process_plate_and_issue_ticket(
     camera_ip: str,
     camera_user: str,
     camera_pass: str,
-    parkonic_api_token: str
+    parkonic_api_token: str,
+    rtsp_path: str = "/"
 ):
     """
     1) Re-open saved snapshot, annotate & crop the parking region.
@@ -261,7 +262,12 @@ def process_plate_and_issue_ticket(
         # Fallback: capture a fresh frame and retry detection/OCR if unread
         if plate_status == "UNREAD":
             try:
-                frame_bytes = fetch_camera_frame(camera_ip, camera_user or "", camera_pass or "")
+                frame_bytes = fetch_camera_frame(
+                    camera_ip,
+                    camera_user or "",
+                    camera_pass or "",
+                    rtsp_path=rtsp_path,
+                )
                 retry_snapshot = os.path.join(park_folder, f"retry_snapshot_{ts}.jpg")
                 with open(retry_snapshot, "wb") as f:
                     f.write(frame_bytes)

--- a/tests/test_fetch_camera_frame_retry.py
+++ b/tests/test_fetch_camera_frame_retry.py
@@ -24,3 +24,15 @@ def test_fetch_camera_frame_retries_until_frame():
 
     assert result == bytes([1, 2, 3])
     assert dummy_stream.read.call_count == 3
+
+
+def test_fetch_camera_frame_custom_path():
+    dummy_stream = MagicMock()
+    dummy_stream.read.return_value = 'frame'
+    dummy_stream.start.return_value = dummy_stream
+
+    with patch('camera_clip.VideoStream', return_value=dummy_stream) as vs, \
+         patch('cv2.imencode', return_value=(True, np.array([1], dtype=np.uint8))):
+        camera_clip.fetch_camera_frame('ip', 'u', 'p', rtsp_path='/foo', max_attempts=1)
+
+    vs.assert_called_with('rtsp://u:p@ip:554/foo')


### PR DESCRIPTION
## Summary
- extend `fetch_camera_frame` with optional `rtsp_path`
- allow `/cameras/{id}/frame` to pull `rtsp_path` from location parameters
- thread worker functions pass the path through to plate processing
- support `rtsp_path` in OCR processing
- test new parameter handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853ef6bf1108326ad14dbc3cf0bd805