### PR TITLE
Fix camera frame endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1464,7 +1464,7 @@ def get_camera_frame(
         row = db.execute(
             text(
                 """
-                SELECT c.p_ip, l.camera_user, l.camera_pass
+                SELECT c.p_ip, l.camera_user, l.camera_pass, l.parameters
                 FROM cameras c
                 JOIN poles p ON c.pole_id = p.id
                 JOIN locations l ON p.location_id = l.id
@@ -1487,9 +1487,6 @@ def get_camera_frame(
                 rtsp_path = params.get("rtsp_path", "/") if isinstance(params, dict) else "/"
             except Exception:
                 rtsp_path = "/"
-        print(cam_ip)
-        print(user)
-        print(pwd)
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- include location parameters when looking up a camera for frame grabbing
- remove leftover debug prints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853f6973e548326a36d1c4af43c2fca